### PR TITLE
feat: add get-content command for path-based content lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Thumbs.db
 
 # Homebrew formula (lives in homebrew-tap repo)
 Formula/
+
+.plans

--- a/lib/sumologic.rb
+++ b/lib/sumologic.rb
@@ -57,6 +57,7 @@ require_relative 'sumologic/metadata/health_event'
 require_relative 'sumologic/metadata/field'
 require_relative 'sumologic/metadata/lookup_table'
 require_relative 'sumologic/metadata/app'
+require_relative 'sumologic/metadata/content'
 
 # Load main client (facade)
 require_relative 'sumologic/client'

--- a/lib/sumologic/cli.rb
+++ b/lib/sumologic/cli.rb
@@ -15,6 +15,7 @@ require_relative 'cli/commands/list_health_events_command'
 require_relative 'cli/commands/list_fields_command'
 require_relative 'cli/commands/get_lookup_command'
 require_relative 'cli/commands/list_apps_command'
+require_relative 'cli/commands/get_content_command'
 
 module Sumologic
   # Thor-based CLI for Sumo Logic query tool
@@ -362,6 +363,29 @@ module Sumologic
     def list_apps
       Commands::ListAppsCommand.new(options, create_client).execute
     end
+
+    # ============================================================
+    # Content Library Commands (path-based)
+    # ============================================================
+
+    desc 'get-content', 'Get a content item by its library path'
+    long_desc <<~DESC
+      Look up a content item in the Sumo Logic content library by its path.
+      Returns the item ID, type, name, and parent folder.
+
+      Examples:
+        # Get content by path
+        sumo-query get-content --path '/Library/Users/me/My Saved Search'
+
+        # Save to file
+        sumo-query get-content --path '/Library/Users/me/Dashboard' --output content.json
+    DESC
+    option :path, type: :string, required: true, aliases: '-p', desc: 'Content library path'
+    # rubocop:disable Naming/AccessorMethodName -- Thor CLI command, not a getter
+    def get_content
+      Commands::GetContentCommand.new(options, create_client).execute
+    end
+    # rubocop:enable Naming/AccessorMethodName
 
     # ============================================================
     # Utility Commands

--- a/lib/sumologic/cli/commands/get_content_command.rb
+++ b/lib/sumologic/cli/commands/get_content_command.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base_command'
+
+module Sumologic
+  class CLI < Thor
+    module Commands
+      # Handles the get-content command execution
+      class GetContentCommand < BaseCommand
+        def execute
+          path = options[:path]
+          warn "Looking up content at path: #{path}..."
+          content = client.get_content(path: path)
+
+          output_json(content)
+        end
+      end
+    end
+  end
+end

--- a/lib/sumologic/client.rb
+++ b/lib/sumologic/client.rb
@@ -44,6 +44,7 @@ module Sumologic
       @field = Metadata::Field.new(http_client: @http)
       @lookup_table = Metadata::LookupTable.new(http_client: @http)
       @app = Metadata::App.new(http_client: @http)
+      @content = Metadata::Content.new(http_client: @http_v2) # Uses v2 API
     end
 
     # Search logs with query
@@ -244,6 +245,17 @@ module Sumologic
     # List available apps from the Sumo Logic app catalog
     def list_apps
       @app.list
+    end
+
+    # ============================================================
+    # Content Library API (path-based)
+    # ============================================================
+
+    # Get a content item by its library path
+    #
+    # @param path [String] Content library path (e.g., '/Library/Users/me/My Search')
+    def get_content(path:)
+      @content.get_by_path(path)
     end
   end
 end

--- a/lib/sumologic/metadata/content.rb
+++ b/lib/sumologic/metadata/content.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'loggable'
+
+module Sumologic
+  module Metadata
+    # Handles content library path-based operations
+    # Uses GET /v2/content/path endpoint
+    class Content
+      include Loggable
+
+      def initialize(http_client:)
+        @http = http_client
+      end
+
+      # Get a content item by its library path
+      # Returns item ID, type, name, and parent folder
+      #
+      # @param path [String] Content library path (e.g., '/Library/Users/me/My Search')
+      # @return [Hash] Content item data
+      def get_by_path(path)
+        data = @http.request(
+          method: :get,
+          path: '/content/path',
+          query_params: { path: path }
+        )
+
+        log_info "Retrieved content at path: #{path}"
+        data
+      rescue StandardError => e
+        raise Error, "Failed to get content at path '#{path}': #{e.message}"
+      end
+    end
+  end
+end

--- a/spec/sumologic/client_spec.rb
+++ b/spec/sumologic/client_spec.rb
@@ -170,5 +170,10 @@ RSpec.describe Sumologic::Client do
     it 'responds to list_apps' do
       expect(client).to respond_to(:list_apps)
     end
+
+    # Content Library API
+    it 'responds to get_content' do
+      expect(client).to respond_to(:get_content)
+    end
   end
 end

--- a/spec/sumologic/metadata/content_spec.rb
+++ b/spec/sumologic/metadata/content_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Sumologic::Metadata::Content do
+  let(:http_client) { instance_double('Sumologic::Http::Client') }
+  let(:content) { described_class.new(http_client: http_client) }
+
+  describe '#get_by_path' do
+    it 'returns content item for a valid path' do
+      response = {
+        'id' => 'content123',
+        'name' => 'My Saved Search',
+        'itemType' => 'Search',
+        'parentId' => 'folder456',
+        'createdAt' => '2025-01-01T00:00:00Z',
+        'createdBy' => 'user789'
+      }
+
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/path', query_params: { path: '/Library/Users/me/My Saved Search' })
+        .and_return(response)
+
+      result = content.get_by_path('/Library/Users/me/My Saved Search')
+      expect(result['id']).to eq('content123')
+      expect(result['name']).to eq('My Saved Search')
+      expect(result['itemType']).to eq('Search')
+      expect(result['parentId']).to eq('folder456')
+    end
+
+    it 'raises Error for invalid path' do
+      allow(http_client).to receive(:request).and_raise(StandardError, 'not found')
+
+      expect { content.get_by_path('/Library/Invalid/Path') }
+        .to raise_error(Sumologic::Error, /Failed to get content at path/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `get-content --path` command that resolves content library paths to items
- Uses `GET /v2/content/path?path=...` endpoint
- Returns item ID, type, name, parent folder, and metadata
- New `Content` metadata class for content library operations (v2 API)

## Test plan
- [x] All existing tests pass
- [x] New content tests cover path lookup and error handling
- [x] Client spec updated for `get_content` method