### PR TITLE
feat: add get-lookup and list-apps commands

### DIFF
--- a/lib/sumologic.rb
+++ b/lib/sumologic.rb
@@ -55,6 +55,8 @@ require_relative 'sumologic/metadata/folder'
 require_relative 'sumologic/metadata/dashboard'
 require_relative 'sumologic/metadata/health_event'
 require_relative 'sumologic/metadata/field'
+require_relative 'sumologic/metadata/lookup_table'
+require_relative 'sumologic/metadata/app'
 
 # Load main client (facade)
 require_relative 'sumologic/client'

--- a/lib/sumologic/cli.rb
+++ b/lib/sumologic/cli.rb
@@ -13,6 +13,8 @@ require_relative 'cli/commands/list_dashboards_command'
 require_relative 'cli/commands/get_dashboard_command'
 require_relative 'cli/commands/list_health_events_command'
 require_relative 'cli/commands/list_fields_command'
+require_relative 'cli/commands/get_lookup_command'
+require_relative 'cli/commands/list_apps_command'
 
 module Sumologic
   # Thor-based CLI for Sumo Logic query tool
@@ -320,6 +322,45 @@ module Sumologic
     option :builtin, type: :boolean, desc: 'List built-in fields instead of custom fields'
     def list_fields
       Commands::ListFieldsCommand.new(options, create_client).execute
+    end
+
+    # ============================================================
+    # Lookup Tables Commands
+    # ============================================================
+
+    desc 'get-lookup', 'Get a specific lookup table by ID'
+    long_desc <<~DESC
+      Get detailed information about a specific lookup table.
+      Note: There is no list-all endpoint for lookup tables in the Sumo Logic API.
+
+      Example:
+        sumo-query get-lookup --lookup-id 0000000000123456
+    DESC
+    option :lookup_id, type: :string, required: true, desc: 'Lookup table ID'
+    # rubocop:disable Naming/AccessorMethodName -- Thor CLI command, not a getter
+    def get_lookup
+      Commands::GetLookupCommand.new(options, create_client).execute
+    end
+    # rubocop:enable Naming/AccessorMethodName
+
+    # ============================================================
+    # Apps Commands (Catalog)
+    # ============================================================
+
+    desc 'list-apps', 'List available apps from the Sumo Logic catalog'
+    long_desc <<~DESC
+      List apps available in the Sumo Logic app catalog.
+      Note: This lists the catalog of available apps, not installed apps.
+
+      Examples:
+        # List all available apps
+        sumo-query list-apps
+
+        # Save to file
+        sumo-query list-apps --output apps.json
+    DESC
+    def list_apps
+      Commands::ListAppsCommand.new(options, create_client).execute
     end
 
     # ============================================================

--- a/lib/sumologic/cli/commands/get_lookup_command.rb
+++ b/lib/sumologic/cli/commands/get_lookup_command.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base_command'
+
+module Sumologic
+  class CLI < Thor
+    module Commands
+      # Handles the get-lookup command execution
+      class GetLookupCommand < BaseCommand
+        def execute
+          lookup_id = options[:lookup_id]
+          warn "Fetching lookup table #{lookup_id}..."
+          lookup = client.get_lookup(lookup_id: lookup_id)
+
+          output_json(lookup)
+        end
+      end
+    end
+  end
+end

--- a/lib/sumologic/cli/commands/list_apps_command.rb
+++ b/lib/sumologic/cli/commands/list_apps_command.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'base_command'
+
+module Sumologic
+  class CLI < Thor
+    module Commands
+      # Handles the list-apps command execution
+      class ListAppsCommand < BaseCommand
+        def execute
+          warn 'Fetching app catalog...'
+          apps = client.list_apps
+
+          output_json(
+            total: apps.size,
+            apps: apps.map { |a| format_app(a) }
+          )
+        end
+
+        private
+
+        def format_app(app)
+          {
+            appId: app['appId'] || app['uuid'],
+            name: app['appDefinition']&.dig('name') || app['name'],
+            description: app['appDefinition']&.dig('description') || app['description']
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/sumologic/client.rb
+++ b/lib/sumologic/client.rb
@@ -42,6 +42,8 @@ module Sumologic
       @dashboard = Metadata::Dashboard.new(http_client: @http_v2)
       @health_event = Metadata::HealthEvent.new(http_client: @http)
       @field = Metadata::Field.new(http_client: @http)
+      @lookup_table = Metadata::LookupTable.new(http_client: @http)
+      @app = Metadata::App.new(http_client: @http)
     end
 
     # Search logs with query
@@ -221,6 +223,27 @@ module Sumologic
     # List built-in fields
     def list_builtin_fields
       @field.list_builtin
+    end
+
+    # ============================================================
+    # Lookup Tables API
+    # ============================================================
+
+    # Get a specific lookup table by ID
+    # Note: There is no list-all endpoint for lookup tables
+    #
+    # @param lookup_id [String] The lookup table ID
+    def get_lookup(lookup_id:)
+      @lookup_table.get(lookup_id)
+    end
+
+    # ============================================================
+    # Apps API (Catalog)
+    # ============================================================
+
+    # List available apps from the Sumo Logic app catalog
+    def list_apps
+      @app.list
     end
   end
 end

--- a/lib/sumologic/metadata/app.rb
+++ b/lib/sumologic/metadata/app.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'loggable'
+
+module Sumologic
+  module Metadata
+    # Handles app catalog operations
+    # Uses GET /v1/apps endpoint
+    # Note: This lists the app catalog (available apps), not installed apps
+    class App
+      include Loggable
+
+      def initialize(http_client:)
+        @http = http_client
+      end
+
+      # List available apps from the Sumo Logic app catalog
+      #
+      # @return [Array<Hash>] Array of app data
+      def list
+        data = @http.request(
+          method: :get,
+          path: '/apps'
+        )
+
+        apps = data['apps'] || []
+        log_info "Fetched #{apps.size} apps from catalog"
+        apps
+      rescue StandardError => e
+        raise Error, "Failed to list apps: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/sumologic/metadata/lookup_table.rb
+++ b/lib/sumologic/metadata/lookup_table.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'loggable'
+
+module Sumologic
+  module Metadata
+    # Handles lookup table operations
+    # Uses GET /v1/lookupTables/{id} endpoint
+    # Note: There is no list-all endpoint for lookup tables
+    class LookupTable
+      include Loggable
+
+      def initialize(http_client:)
+        @http = http_client
+      end
+
+      # Get a specific lookup table by ID
+      #
+      # @param lookup_id [String] The lookup table ID
+      # @return [Hash] Lookup table data
+      def get(lookup_id)
+        data = @http.request(
+          method: :get,
+          path: "/lookupTables/#{lookup_id}"
+        )
+
+        log_info "Retrieved lookup table: #{data['name']} (#{lookup_id})"
+        data
+      rescue StandardError => e
+        raise Error, "Failed to get lookup table #{lookup_id}: #{e.message}"
+      end
+    end
+  end
+end

--- a/spec/sumologic/client_spec.rb
+++ b/spec/sumologic/client_spec.rb
@@ -160,5 +160,15 @@ RSpec.describe Sumologic::Client do
     it 'responds to list_builtin_fields' do
       expect(client).to respond_to(:list_builtin_fields)
     end
+
+    # Lookup Tables API
+    it 'responds to get_lookup' do
+      expect(client).to respond_to(:get_lookup)
+    end
+
+    # Apps API
+    it 'responds to list_apps' do
+      expect(client).to respond_to(:list_apps)
+    end
   end
 end

--- a/spec/sumologic/metadata/app_spec.rb
+++ b/spec/sumologic/metadata/app_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Sumologic::Metadata::App do
+  let(:http_client) { instance_double('Sumologic::Http::Client') }
+  let(:app) { described_class.new(http_client: http_client) }
+
+  describe '#list' do
+    it 'returns apps from the catalog' do
+      response = {
+        'apps' => [
+          { 'appId' => 'a1', 'appDefinition' => { 'name' => 'AWS CloudTrail', 'description' => 'Monitor AWS API calls' } },
+          { 'appId' => 'a2', 'appDefinition' => { 'name' => 'Kubernetes', 'description' => 'Monitor K8s clusters' } }
+        ]
+      }
+
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/apps')
+        .and_return(response)
+
+      result = app.list
+      expect(result.size).to eq(2)
+      expect(result.first['appDefinition']['name']).to eq('AWS CloudTrail')
+    end
+
+    it 'handles empty catalog' do
+      allow(http_client).to receive(:request).and_return({ 'apps' => [] })
+
+      result = app.list
+      expect(result).to be_empty
+    end
+
+    it 'raises Error on failure' do
+      allow(http_client).to receive(:request).and_raise(StandardError, 'forbidden')
+
+      expect { app.list }.to raise_error(Sumologic::Error, /Failed to list apps/)
+    end
+  end
+end

--- a/spec/sumologic/metadata/lookup_table_spec.rb
+++ b/spec/sumologic/metadata/lookup_table_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Sumologic::Metadata::LookupTable do
+  let(:http_client) { instance_double('Sumologic::Http::Client') }
+  let(:lookup_table) { described_class.new(http_client: http_client) }
+
+  describe '#get' do
+    it 'returns a specific lookup table' do
+      response = {
+        'id' => 'lt123',
+        'name' => 'IP Allowlist',
+        'description' => 'Known good IPs',
+        'parentFolderId' => 'folder1',
+        'fields' => [
+          { 'fieldName' => 'ip', 'fieldType' => 'string' },
+          { 'fieldName' => 'label', 'fieldType' => 'string' }
+        ]
+      }
+
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/lookupTables/lt123')
+        .and_return(response)
+
+      result = lookup_table.get('lt123')
+      expect(result['name']).to eq('IP Allowlist')
+      expect(result['fields'].size).to eq(2)
+    end
+
+    it 'raises Error on failure' do
+      allow(http_client).to receive(:request).and_raise(StandardError, 'not found')
+
+      expect { lookup_table.get('bad_id') }.to raise_error(Sumologic::Error, /Failed to get lookup table bad_id/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `get-lookup --lookup-id` command: retrieve a lookup table by ID via `GET /v1/lookupTables/{id}` (no list-all endpoint exists in the API)
- Add `list-apps` command: list the app catalog via `GET /v1/apps` (available apps, not installed apps)
- New `LookupTable` and `App` metadata classes

## Test plan
- [x] All existing tests pass
- [x] LookupTable tests cover get by ID and error handling
- [x] App tests cover catalog listing, empty response, and error handling
- [x] Client spec updated for new methods