### PR TITLE
feat: add export-content command with async job handling

### DIFF
--- a/lib/sumologic/cli.rb
+++ b/lib/sumologic/cli.rb
@@ -16,6 +16,7 @@ require_relative 'cli/commands/list_fields_command'
 require_relative 'cli/commands/get_lookup_command'
 require_relative 'cli/commands/list_apps_command'
 require_relative 'cli/commands/get_content_command'
+require_relative 'cli/commands/export_content_command'
 
 module Sumologic
   # Thor-based CLI for Sumo Logic query tool
@@ -386,6 +387,23 @@ module Sumologic
       Commands::GetContentCommand.new(options, create_client).execute
     end
     # rubocop:enable Naming/AccessorMethodName
+
+    desc 'export-content', 'Export a content item as JSON'
+    long_desc <<~DESC
+      Export a content library item (search, dashboard, folder) as JSON.
+      Handles the async export job automatically (start, poll, fetch result).
+
+      Examples:
+        # Export by content ID
+        sumo-query export-content --content-id 0000000000123456
+
+        # Save export to file
+        sumo-query export-content --content-id 0000000000123456 --output export.json
+    DESC
+    option :content_id, type: :string, required: true, desc: 'Content item ID to export'
+    def export_content
+      Commands::ExportContentCommand.new(options, create_client).execute
+    end
 
     # ============================================================
     # Utility Commands

--- a/lib/sumologic/cli/commands/export_content_command.rb
+++ b/lib/sumologic/cli/commands/export_content_command.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base_command'
+
+module Sumologic
+  class CLI < Thor
+    module Commands
+      # Handles the export-content command execution
+      class ExportContentCommand < BaseCommand
+        def execute
+          content_id = options[:content_id]
+          warn "Exporting content #{content_id}..."
+          result = client.export_content(content_id: content_id)
+
+          output_json(result)
+        end
+      end
+    end
+  end
+end

--- a/lib/sumologic/client.rb
+++ b/lib/sumologic/client.rb
@@ -257,5 +257,13 @@ module Sumologic
     def get_content(path:)
       @content.get_by_path(path)
     end
+
+    # Export a content item as JSON
+    # Handles async job lifecycle: start → poll → fetch result
+    #
+    # @param content_id [String] The content item ID to export
+    def export_content(content_id:)
+      @content.export(content_id)
+    end
   end
 end

--- a/lib/sumologic/metadata/content.rb
+++ b/lib/sumologic/metadata/content.rb
@@ -4,10 +4,13 @@ require_relative 'loggable'
 
 module Sumologic
   module Metadata
-    # Handles content library path-based operations
-    # Uses GET /v2/content/path endpoint
+    # Handles content library operations
+    # Uses v2 content API endpoints for path lookup and export
     class Content
       include Loggable
+
+      EXPORT_POLL_INTERVAL = 2 # seconds
+      EXPORT_MAX_WAIT = 120 # seconds
 
       def initialize(http_client:)
         @http = http_client
@@ -29,6 +32,63 @@ module Sumologic
         data
       rescue StandardError => e
         raise Error, "Failed to get content at path '#{path}': #{e.message}"
+      end
+
+      # Export a content item as JSON
+      # Handles the async job lifecycle: start → poll → fetch result
+      #
+      # @param content_id [String] The content item ID to export
+      # @return [Hash] Exported content data
+      def export(content_id)
+        # Start export job
+        job = @http.request(
+          method: :post,
+          path: "/content/#{content_id}/export"
+        )
+        job_id = job['id']
+        log_info "Started export job #{job_id} for content #{content_id}"
+
+        # Poll until complete
+        poll_export_status(content_id, job_id)
+
+        # Fetch result
+        result = @http.request(
+          method: :get,
+          path: "/content/#{content_id}/export/#{job_id}/result"
+        )
+
+        log_info "Export complete for content #{content_id}"
+        result
+      rescue StandardError => e
+        raise Error, "Failed to export content #{content_id}: #{e.message}"
+      end
+
+      private
+
+      def poll_export_status(content_id, job_id)
+        start_time = Time.now
+
+        loop do
+          elapsed = Time.now - start_time
+          raise TimeoutError, "Export job timed out after #{EXPORT_MAX_WAIT}s" if elapsed > EXPORT_MAX_WAIT
+
+          status = @http.request(
+            method: :get,
+            path: "/content/#{content_id}/export/#{job_id}/status"
+          )
+
+          state = status['status']
+          log_info "Export status: #{state}"
+
+          case state
+          when 'Success'
+            return
+          when 'Failed'
+            raise Error, "Export job failed: #{status['error']&.dig('message') || 'unknown error'}"
+          end
+
+          sleep EXPORT_POLL_INTERVAL
+        end
       end
     end
   end

--- a/spec/sumologic/client_spec.rb
+++ b/spec/sumologic/client_spec.rb
@@ -175,5 +175,9 @@ RSpec.describe Sumologic::Client do
     it 'responds to get_content' do
       expect(client).to respond_to(:get_content)
     end
+
+    it 'responds to export_content' do
+      expect(client).to respond_to(:export_content)
+    end
   end
 end

--- a/spec/sumologic/metadata/content_spec.rb
+++ b/spec/sumologic/metadata/content_spec.rb
@@ -33,4 +33,72 @@ RSpec.describe Sumologic::Metadata::Content do
         .to raise_error(Sumologic::Error, /Failed to get content at path/)
     end
   end
+
+  describe '#export' do
+    it 'runs the full async export lifecycle' do
+      # Start export job
+      allow(http_client).to receive(:request)
+        .with(method: :post, path: '/content/abc123/export')
+        .and_return({ 'id' => 'job456' })
+
+      # Poll status - returns Success immediately
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/abc123/export/job456/status')
+        .and_return({ 'status' => 'Success' })
+
+      # Fetch result
+      exported_content = { 'type' => 'SavedSearchWithScheduleSyncDefinition', 'name' => 'My Search' }
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/abc123/export/job456/result')
+        .and_return(exported_content)
+
+      result = content.export('abc123')
+      expect(result['name']).to eq('My Search')
+    end
+
+    it 'polls until export completes' do
+      allow(http_client).to receive(:request)
+        .with(method: :post, path: '/content/abc123/export')
+        .and_return({ 'id' => 'job456' })
+
+      # First poll: InProgress, second: Success
+      call_count = 0
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/abc123/export/job456/status') do
+        call_count += 1
+        { 'status' => call_count >= 2 ? 'Success' : 'InProgress' }
+      end
+
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/abc123/export/job456/result')
+        .and_return({ 'name' => 'Done' })
+
+      # Stub sleep to avoid waiting
+      allow(content).to receive(:sleep)
+
+      result = content.export('abc123')
+      expect(result['name']).to eq('Done')
+      expect(call_count).to be >= 2
+    end
+
+    it 'raises Error when export job fails' do
+      allow(http_client).to receive(:request)
+        .with(method: :post, path: '/content/bad/export')
+        .and_return({ 'id' => 'job789' })
+
+      allow(http_client).to receive(:request)
+        .with(method: :get, path: '/content/bad/export/job789/status')
+        .and_return({ 'status' => 'Failed', 'error' => { 'message' => 'content not found' } })
+
+      expect { content.export('bad') }
+        .to raise_error(Sumologic::Error, /Failed to export content bad/)
+    end
+
+    it 'raises Error on network failure' do
+      allow(http_client).to receive(:request).and_raise(StandardError, 'connection refused')
+
+      expect { content.export('abc123') }
+        .to raise_error(Sumologic::Error, /Failed to export content abc123/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `export-content --content-id` command for exporting content library items as JSON
- Handles async job lifecycle transparently: `POST /v2/content/{id}/export` → poll status → fetch result
- 120s timeout with 2s polling interval

## Test plan
- [x] All existing tests pass (138 total)
- [x] Full async lifecycle test (start → poll → fetch)
- [x] Polling test with multiple status transitions
- [x] Error handling for failed exports and network failures